### PR TITLE
Fixed Foreground bug in PlotAxis

### DIFF
--- a/src/Axes/PlotAxis.cs
+++ b/src/Axes/PlotAxis.cs
@@ -30,7 +30,6 @@ namespace InteractiveDataDisplay.WPF
             DefaultStyleKey = typeof(PlotAxis);
             Loaded += PlotAxisLoaded;
             Unloaded += PlotAxisUnloaded;
-            Foreground = new SolidColorBrush(Colors.Black);
         }
 
         private void PlotAxisUnloaded(object sender, RoutedEventArgs e)


### PR DESCRIPTION
PlotAxis constructor would override Foreground colour property with Colors.Black, making it unusable for dark themes (white-on-black instead of black-on-white).

With this line simply removed, it respects the Foreground property inherited from the Chart.