### PR TITLE
Minor bugfix in data binding

### DIFF
--- a/src/Axes/Axis.cs
+++ b/src/Axes/Axis.cs
@@ -200,16 +200,16 @@ namespace InteractiveDataDisplay.WPF
         /// <remarks>The default foreground is black</remarks>
         [Category("Appearance")]
         [Description("Brush for labels and ticks")]
-        public SolidColorBrush Foreground
+        public Brush Foreground
         {
-            get { return (SolidColorBrush)GetValue(ForegroundProperty); }
+            get { return (Brush)GetValue(ForegroundProperty); }
             set { SetValue(ForegroundProperty, value); }
         }
         /// <summary>
         /// Identifies the <see cref="Foreground"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty ForegroundProperty =
-            DependencyProperty.Register("Foreground", typeof(SolidColorBrush), typeof(Axis), new PropertyMetadata(new SolidColorBrush(Colors.Black)));
+            DependencyProperty.Register("Foreground", typeof(Brush), typeof(Axis), new PropertyMetadata(new SolidColorBrush(Colors.Black)));
 
         /// <summary>
         /// Gets or sets the maximum possible count of ticks.

--- a/src/Axes/AxisGrid.cs
+++ b/src/Axes/AxisGrid.cs
@@ -52,7 +52,7 @@ namespace InteractiveDataDisplay.WPF
         /// Identifies the <see cref="Stroke"/> dependency property
         /// </summary>
         public static readonly DependencyProperty StrokeProperty =
-            DependencyProperty.Register("Stroke", typeof(SolidColorBrush), typeof(AxisGrid), new PropertyMetadata(new SolidColorBrush(Colors.LightGray),
+            DependencyProperty.Register("Stroke", typeof(Brush), typeof(AxisGrid), new PropertyMetadata(new SolidColorBrush(Colors.LightGray),
                 (o, e) =>
                 {
                     AxisGrid axisGrid = (AxisGrid)o;
@@ -120,9 +120,9 @@ namespace InteractiveDataDisplay.WPF
         /// Gets or sets the Brush that specifies how the horizontal and vertical lines is painted
         /// </summary>
         [Category("Appearance")]
-        public SolidColorBrush Stroke
+        public Brush Stroke
         {
-            get { return (SolidColorBrush)GetValue(StrokeProperty); }
+            get { return (Brush)GetValue(StrokeProperty); }
             set { SetValue(StrokeProperty, value); }
         }
 


### PR DESCRIPTION
**The error happens when using default d3:Chart control:**

> System.Windows.Data Error: 1 : Cannot create default converter to perform 'two-way' conversions between types 'System.Windows.Media.SolidColorBrush' and 'System.Windows.Media.Brush'. Consider using Converter property of Binding. BindingExpression:Path=Stroke; DataItem='AxisGrid' (Name=''); target element is 'Path' (Name=''); target property is 'Stroke' (type 'Brush')
System.Windows.Data Error: 1 : Cannot create default converter to perform 'two-way' conversions between types 'System.Windows.Media.SolidColorBrush' and 'System.Windows.Media.Brush'. Consider using Converter property of Binding. BindingExpression:Path=Foreground; DataItem='Axis' (Name=''); target element is 'Path' (Name=''); target property is 'Stroke' (type 'Brush')
System.Windows.Data Error: 1 : Cannot create default converter to perform 'two-way' conversions between types 'System.Windows.Media.SolidColorBrush' and 'System.Windows.Media.Brush'. Consider using Converter property of Binding. BindingExpression:Path=Foreground; DataItem='Axis' (Name=''); target element is 'Path' (Name=''); target property is 'Stroke' (type 'Brush')
System.Windows.Data Error: 1 : Cannot create default converter to perform 'two-way' conversions between types 'System.Windows.Media.Brush' and 'System.Windows.Media.SolidColorBrush'. Consider using Converter property of Binding. BindingExpression:Path=Foreground; DataItem='PlotAxis' (Name='PART_horizontalAxis'); target element is 'Axis' (Name=''); target property is 'Foreground' (type 'SolidColorBrush')
System.Windows.Data Error: 1 : Cannot create default converter to perform 'two-way' conversions between types 'System.Windows.Media.SolidColorBrush' and 'System.Windows.Media.Brush'. Consider using Converter property of Binding. BindingExpression:Path=Foreground; DataItem='Axis' (Name=''); target element is 'Path' (Name=''); target property is 'Stroke' (type 'Brush')
System.Windows.Data Error: 1 : Cannot create default converter to perform 'two-way' conversions between types 'System.Windows.Media.SolidColorBrush' and 'System.Windows.Media.Brush'. Consider using Converter property of Binding. BindingExpression:Path=Foreground; DataItem='Axis' (Name=''); target element is 'Path' (Name=''); target property is 'Stroke' (type 'Brush')
System.Windows.Data Error: 1 : Cannot create default converter to perform 'two-way' conversions between types 'System.Windows.Media.Brush' and 'System.Windows.Media.SolidColorBrush'. Consider using Converter property of Binding. BindingExpression:Path=Foreground; DataItem='PlotAxis' (Name='PART_verticalAxis'); target element is 'Axis' (Name=''); target property is 'Foreground' (type 'SolidColorBrush')

Fixed by changing Axis.Foreground and AxisGrid.Stroke from "SolidColorBrush" to "Brush", so that these properties can be successfully bound to other "Foreground(type 'Brush')" properties.